### PR TITLE
Disable Naming/InclusiveLanguage

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -58,7 +58,12 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   Enabled: false
 
-#################### RSpec ###############################
+#################### Naming ###############################
+
+Naming/InclusiveLanguage:
+  Enabled: false
+
+  #################### RSpec ###############################
 
 RSpec/ExampleLength:
   Enabled: false


### PR DESCRIPTION
I think this is a great Cop, but unfortunately default rails uses
phrasing such as master_key. Once I figure out how to adequately control
this Cop, I will need to disable it so I can pass the tests and merge
the branch.